### PR TITLE
Remove class dstName filtering if equals to srcName

### DIFF
--- a/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
+++ b/src/main/java/net/fabricmc/mappingio/format/enigma/EnigmaWriterBase.java
@@ -29,7 +29,7 @@ import net.fabricmc.mappingio.MappingFlag;
 import net.fabricmc.mappingio.MappingWriter;
 
 abstract class EnigmaWriterBase implements MappingWriter {
-	EnigmaWriterBase(Writer writer) throws IOException {
+	EnigmaWriterBase(Writer writer) {
 		this.writer = writer;
 	}
 
@@ -185,10 +185,8 @@ abstract class EnigmaWriterBase implements MappingWriter {
 						if (dstEnd < 0) dstEnd = dstName.length();
 						int dstLen = dstEnd - dstStart;
 
-						if (dstLen != srcLen || !srcClassName.regionMatches(srcStart, dstName, dstStart, srcLen)) { // src != dst
-							writer.write(' ');
-							writer.write(dstName, dstStart, dstLen);
-						}
+						writer.write(' ');
+						writer.write(dstName, dstStart, dstLen);
 					}
 				}
 


### PR DESCRIPTION
I am trying to fix a bug in Enigma that annoys me since the very beginning: I cannot map classes to themselves. I have a .jar file that has a few classes that are not obfuscated, and each time I mark them as mapped (basically mapping the class name to itself), the mapping is not saved correctly.
To be more specific, if I have a class X that is originally non-mapped and it turns out that X is its real, non-obfuscated name, I want my mapping file to contain the line CLASS X X but right now it contains CLASS X.

This PR should remove the problematic filtering.
